### PR TITLE
Disable PWM when braking DC motor

### DIFF
--- a/Code/Fahren_Tests/lib/dc_motor/dc_motor.cpp
+++ b/Code/Fahren_Tests/lib/dc_motor/dc_motor.cpp
@@ -13,6 +13,7 @@ DC_Motor::DC_Motor(int _IN1, int _IN2, int _ENA){
 void DC_Motor::brake(){
     digitalWrite(IN1, LOW);
     digitalWrite(IN2, LOW);
+    analogWrite(ENA, 0);
 }
 
 void DC_Motor::forward(int speed){


### PR DESCRIPTION
## Summary
- ensure DC motor brake disables PWM output

## Testing
- `pio test` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio, proxy error 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a72bef80448332af13bab062f4652f