### PR TITLE
Add proportional steering control while searching for container

### DIFF
--- a/Code/EcoDrop3_Arduino/include/bewegung.h
+++ b/Code/EcoDrop3_Arduino/include/bewegung.h
@@ -25,6 +25,7 @@ void turnRightSlow(float deg);
 void moveLeft(int distancemm);
 void moveRight(int distancemm);
 void moveForwardParallelUntilContainer(uint16_t distanceToWall);
+void driveForwardWithWheelCorrection(int baseSpeed, int correction, unsigned long durationMs);
 void rechtsKurve(int distancemm);
 void linksKurve(int distancemm);
 void moveToRightWall(uint16_t distanceToWall);


### PR DESCRIPTION
## Summary
- add differential wheel-speed helper for forward movement corrections
- apply a proportional controller in moveForwardParallelUntilContainer to keep alignment while searching for a container

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ae0883e908332b8d557fb674ddbb2)